### PR TITLE
.moveTo was renamed to .select in version 0.17.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function AutoWrapBlock(opts) {
       let transform = state.transform()
       for (const wrappedBlockKey of wrappedBlockKeys) {
         transform = transform
-          .moveTo({ anchorKey: wrappedBlockKey, anchorOffset: 0 })
+          .select({ anchorKey: wrappedBlockKey, anchorOffset: 0 })
           .unwrapBlock(opts.type)
       }
       state = transform.apply()
@@ -104,7 +104,7 @@ function AutoWrapBlock(opts) {
 
     let transform = removedAllWrappedBlockState
       .transform()
-      .moveTo(selection)
+      .select(selection)
 
     const currentNode = state.blocks.first()
     if (opts.condition(currentNode)) {


### PR DESCRIPTION
This currently just triggers a deprecation warning, but will break in the future. Here is the [changelog](https://github.com/ianstormtaylor/slate/blob/master/Changelog.md)